### PR TITLE
Allow closure to unsafe fn coercion

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -8,7 +8,7 @@ You must configure your shell to enable the completion support. This is because 
 
 ## Configuring Completions in `bash`
 
-To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell startup. Add the following to your `~/.bashrc` file:
+To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell startup. Add the following to your `~/.bash_profile` file:
 
 ```sh
 if type brew &>/dev/null; then


### PR DESCRIPTION
`.bashrc` is not the right location for shell completions.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
